### PR TITLE
Rename OSCMessage Init - Closes #12

### DIFF
--- a/Sources/OSCKit/OSCAnnotation.swift
+++ b/Sources/OSCKit/OSCAnnotation.swift
@@ -126,7 +126,7 @@ public class OSCAnnotation {
                         }
                     }
                 }
-                return OSCMessage(messageWithAddressPattern: String(addressPattern), arguments: oscArguments)
+                return OSCMessage(with: String(addressPattern), arguments: oscArguments)
             } catch {
                 return nil
             }
@@ -182,7 +182,7 @@ public class OSCAnnotation {
                         
                     }
                 }
-                return OSCMessage(messageWithAddressPattern: String(addressPattern), arguments: oscArguments)
+                return OSCMessage(with: String(addressPattern), arguments: oscArguments)
             } catch {
                 return nil
             }

--- a/Sources/OSCKit/OSCMessage.swift
+++ b/Sources/OSCKit/OSCMessage.swift
@@ -37,7 +37,11 @@ public class OSCMessage: OSCPacket {
     public let argumentTypes: [OSCArgument]
     public var replySocket: Socket? = nil
     
-    public init(messageWithAddressPattern addressPattern: String, arguments: [Any]) {
+    /// Creates an OSC Message
+    /// - Parameters:
+    ///   - addressPattern: An OSC-string beginning with the character '/' (forward slash).
+    ///   - arguments: A sequence of OSC Arguments (String, Int, Float, Data, OSCTimetag, OSCTrue, OSCFalse, OSCNil, OSCImpulse)
+    public init(with addressPattern: String, arguments: [Any]) {
         if addressPattern.isEmpty || addressPattern.count == 0 || addressPattern.first != "/" {
             self.addressPattern = "/"
         } else {

--- a/Sources/OSCKit/OSCParser.swift
+++ b/Sources/OSCKit/OSCParser.swift
@@ -250,7 +250,7 @@ public class OSCParser {
                 }
             }
         }
-        return OSCMessage(messageWithAddressPattern: addressPattern, arguments: arguments)
+        return OSCMessage(with: addressPattern, arguments: arguments)
     }
     
     private func parseOSCBundle(with data: Data) throws -> OSCBundle {


### PR DESCRIPTION
A superficial change to shorten the init method name and bring it more inline with Apple styling.

It would require amendments in all codebases using OSCMessage, although shouldn't take long with a find and replace...