### PR TITLE
30 Build errors: The package product 'CocoaAsyncSocket' requires minimum platform version 9.0 for the iOS platform, but this target supports 8.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,11 @@ import PackageDescription
 
 let package = Package(
     name: "OSCKit",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_10),
+        .tvOS(.v9)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Added minimum platform requirements
